### PR TITLE
git: Add metadata to the result of `git archive`

### DIFF
--- a/.gitarchive-info
+++ b/.gitarchive-info
@@ -1,0 +1,2 @@
+Changeset: $Format:%H$
+Commit date: $Format:%cD$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.gitarchive-info export-subst


### PR DESCRIPTION
Have `git archive` automatically fill in metadata at the point of creating
the archive, which makes it easier to track back from released packages
to the source code which was used to build them.   .gitarchive-info will
contain something like the following:

> Changeset: ccd5d2e265d1d629004aa05f6f873ab6f49555c2
> Commit date: Mon, 7 Nov 2016 09:51:32 +0000

Based on https://xenbits.xen.org/gitweb/?p=xen.git;a=commitdiff;h=bd4d31be073166fc69b131e6375b55033b83b1c0

Suggested-by: Andrew Cooper <andrew.cooper3@citrix.com>
Signed-off-by: Euan Harris <euan.harris@citrix.com>